### PR TITLE
add fix to resume training and fix small bug

### DIFF
--- a/recipes/full_finetune_fsdp2.py
+++ b/recipes/full_finetune_fsdp2.py
@@ -700,8 +700,8 @@ class FullFinetuneRecipeFSDP2(FTRecipeInterface):
                     num_tokens = 0
                     t0 = time.perf_counter()
                     # for debugging purposes, break after 5 steps
-                    if self.global_step == 11:
-                        log.info(f"The Data for step 11 is: {batch['tokens']}")
+                    # if self.global_step == 11:
+                    #     log.info(f"The Data for step 11 is: {batch['tokens']}")
 
             self.epochs_run += 1
             self.save_checkpoint(epoch=curr_epoch)

--- a/recipes/full_finetune_fsdp2.py
+++ b/recipes/full_finetune_fsdp2.py
@@ -10,7 +10,7 @@ import json
 from functools import partial
 from typing import Any, Dict, Optional, Tuple
 from warnings import warn
-
+import itertools
 import torch
 from omegaconf import DictConfig, ListConfig
 
@@ -614,7 +614,8 @@ class FullFinetuneRecipeFSDP2(FTRecipeInterface):
                 disable=not (rank == 0),
                 initial=self.local_step,
             )
-            for idx, batch in enumerate(self._dataloader):
+            start_batch = self.global_step % len(self._dataloader) if self._resume_from_checkpoint else 0
+            for idx, batch in itertools.islice(enumerate(self._dataloader), start_batch, None):
                 if (
                     self.max_steps_per_epoch is not None
                     and (idx // self._gradient_accumulation_steps)
@@ -699,8 +700,8 @@ class FullFinetuneRecipeFSDP2(FTRecipeInterface):
                     num_tokens = 0
                     t0 = time.perf_counter()
                     # for debugging purposes, break after 5 steps
-                    # if self.global_step == 5:
-                    #     break
+                    if self.global_step == 11:
+                        log.info(f"The Data for step 11 is: {batch['tokens']}")
 
             self.epochs_run += 1
             self.save_checkpoint(epoch=curr_epoch)

--- a/torchtune/models/llama3/_model_builders.py
+++ b/torchtune/models/llama3/_model_builders.py
@@ -34,7 +34,7 @@ def llama3_s_tokenizer(path: str, special_tokens_path: Optional[str] = None, max
         Llama3Tokenizer: Instantiation of the Llama3S tokenizer with sound tokens
     """
     special_tokens = parse_hf_tokenizer_json(special_tokens_path) if special_tokens_path is not None else None
-    return Llama3Tokenizer(path=path, special_tokens=special_tokens, max_seq_len=max_seq_len)
+    return Llama3STokenizer(path=path, special_tokens=special_tokens, max_seq_len=max_seq_len)
 
 
 def llama3_s_8b(path: str, special_tokens_path: Optional[str] = None) -> TransformerDecoder:


### PR DESCRIPTION
As @tikikun  noted, the resume training process seems to restart from the first step rather than continuing from the last saved step. I've addressed this issue by implementing itertools.